### PR TITLE
✨ タイマーAPIの日別サブタスク時間取得機能を改善し、JSTに基づく日付変換を追加。SQL関数での時間集計をUTCからJSTに変更し、正…

### DIFF
--- a/backend/src/routes/timer-routing.ts
+++ b/backend/src/routes/timer-routing.ts
@@ -26,12 +26,21 @@ router.get("/", async (req, res) => {
 // サブタスクの時間を日付ごとに取得
 router.get("/daily-time", async( req, res) => {
   const today = new Date()
-  const isoDate: string = today.toISOString().split("T")[0];  // "2025-07-08"
-  console.log(isoDate)
 
-  const startDate = new Date(today.getTime()-(13 * 24 * 60 * 60 * 1000))
-  const isoTwoWeeksAgo: string = startDate.toISOString().split("T")[0];
-  console.log(isoTwoWeeksAgo)
+  const convertDate = (date:any) => {
+    return new Date(date).toLocaleDateString("sv-SE") // yyyy-mm-dd形式になる
+  }
+  console.log("convertDate(today)",convertDate(today))
+
+  const localDate = convertDate(today)
+  
+  // getTimeはUTCで取得。ここで1日ずれる可能性
+  const startDate = new Date(today.getTime()-(13 * 24 * 60 * 60 * 1000)) // 13日前をミリ秒で指定
+  console.log("startDate", startDate)
+  // JSTに変換
+  const startDateJST = new Date(startDate.getTime()+ (1 * 9 * 60 * 60 * 1000))
+  const jstTwoWeeksAgo = convertDate(startDateJST)
+  console.log("jstTwoWeeksAgo", jstTwoWeeksAgo)
 
   // 指定期間の全日付を生成
   const allDates: string[] = [];
@@ -42,8 +51,8 @@ router.get("/daily-time", async( req, res) => {
 
   try {
     const { data, error } = await supabase.rpc("sum_task_daily_times", {
-      start_date: isoTwoWeeksAgo, // 仮指定 "2025-01-01"
-      end_date: isoDate, // 仮指定 "2025-01-01"
+      start_date: jstTwoWeeksAgo, // 仮指定 "2025-01-01"
+      end_date: localDate, // 仮指定 "2025-01-01"
       timezone_name: "Asia/Tokyo"
     })
     console.log("daily-time:",data)

--- a/sql/functions/daily_task_time_aggregation_function.sql
+++ b/sql/functions/daily_task_time_aggregation_function.sql
@@ -5,20 +5,18 @@ create or replace function sum_task_daily_times(
 )
 returns table (
   task_date date,
-  total_seconds bigint,
   total_hours numeric(5,2) --5桁、小数点第二位まで
 ) as $$
 begin
   return query
   SELECT
-    DATE(start_time) as task_date,
-    SUM(task_time) as total_minutes,
+    (start_time + INTERVAL '9 hours')::date as task_date,
     ROUND(SUM(task_time) / 3600.0, 2) as total_hours
   FROM sub_tasks
   WHERE start_time IS NOT NULL
-    AND DATE(start_time) >= start_date
-    AND DATE(start_time) <= end_date
-  GROUP BY DATE(start_time)
-  ORDER BY DATE(start_time) ASC;
+    AND (start_time + INTERVAL '9 hours')::date >= start_date
+    AND (start_time + INTERVAL '9 hours')::date <= end_date
+  GROUP BY (start_time + INTERVAL '9 hours')::date
+  ORDER BY (start_time + INTERVAL '9 hours')::date ASC;
 end;
 $$ language plpgsql;


### PR DESCRIPTION
…確な日付範囲でデータを取得できるようにしました。

タイトルの通り
・SQLエディタ文では、TIMEZONE変換がうまく機能していなかったため、INTERVAL計算でUTC→JSTを変換するように変更